### PR TITLE
Unhandled promise rejections

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Represents a diagnostic level, such as a Information, Warning or Error.
 
 An autoprefixer-like array of browsers. See the [official repository](https://github.com/anandthakker/doiuse) for details.
 
+Through the config files of _browserslist_, it is also possible to define the scope per folder, however, the above VSCode setting has priority over these files.
+
 **doiuse.ignore**
 
   * Type: `Array`

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,13 +2,19 @@
 
 import * as path from 'path';
 
-import { ExtensionContext, workspace } from 'vscode';
+import {
+	ExtensionContext,
+	workspace
+
+} from 'vscode';
+
 import {
 	TransportKind,
 	LanguageClient,
 	SettingMonitor,
 	LanguageClientOptions,
 	ServerOptions
+
 } from 'vscode-languageclient';
 
 export function activate(context: ExtensionContext) {
@@ -41,7 +47,12 @@ export function activate(context: ExtensionContext) {
 		}
 	};
 
-	const client = new LanguageClient('doiuse', 'doiuse language server', serverOptions, clientOptions);
+	const client = new LanguageClient(
+		'doiuse',
+		'doiuse language server',
+		serverOptions,
+		clientOptions
+	);
 
 	// Go to the world
 	context.subscriptions.push(

--- a/src/server.ts
+++ b/src/server.ts
@@ -72,7 +72,7 @@ function makeDiagnostic(problem: any): Diagnostic {
 
 function getErrorMessage(err: Error, document: TextDocument): string {
 	let errorMessage = 'unknown error';
-	if (typeof err.message === 'string' || err.message instanceof String) {
+	if (typeof err.message === 'string' || <any>err.message instanceof String) {
 		errorMessage = err.message;
 	}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -246,11 +246,8 @@ connection.onDidChangeWatchedFiles(() => {
 	validate(allDocuments.all());
 });
 
-// The documents manager listen for text document create,
-// change and close on the connection
 allDocuments.listen(connection);
 
-// A text document has changed. Validate the document.
 allDocuments.onDidChangeContent((event) => {
 	if (editorSettings.run === 'onType') {
 		validate([event.document]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -233,6 +233,7 @@ connection.onInitialize((params) => {
 });
 
 connection.onDidChangeConfiguration((params) => {
+	needUpdateConfig = true;
 	workspaceSettings = params.settings.doiuse;
 
 	validate(allDocuments.all());

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ let editorSettings: any;
 // "config"
 let configResolver: ConfigResolver;
 let needUpdateConfig = true;
-let browserScopeCache: string[] = [];
+let browsersListCache: string[] = [];
 
 const doiuseNotFound: string = [
 	'Failed to load doiuse library.',
@@ -143,7 +143,7 @@ function browsersListParser(data: string): string[] {
 	return browsers;
 }
 
-function getConfig(documentFsPath: string): Promise<string[]> {
+function getBrowsersList(documentFsPath: string): Promise<string[]> {
 	const configResolverOptions: IOptions = {
 		packageProp: 'browserslist',
 		configFiles: [
@@ -156,16 +156,16 @@ function getConfig(documentFsPath: string): Promise<string[]> {
 	};
 
 	if (!needUpdateConfig) {
-		return Promise.resolve(browserScopeCache);
+		return Promise.resolve(browsersListCache);
 	}
 
 	return configResolver
 		.scan(documentFsPath, configResolverOptions)
 		.then((config: IConfig) => {
-			browserScopeCache = <string[]>config.json;
+			browsersListCache = <string[]>config.json;
 			needUpdateConfig = false;
 
-			return browserScopeCache;
+			return browsersListCache;
 		});
 }
 
@@ -189,10 +189,10 @@ function doValidate(document: TextDocument): any {
 		}
 	}
 
-	return getConfig(fsPath)
-		.then((browserScope) => {
+	return getBrowsersList(fsPath)
+		.then((browsersList) => {
 			const linterOptions = {
-				browsers: browserScope,
+				browsers: browsersList,
 				ignore: editorSettings.ignore,
 				onFeatureUsage: (usageInfo: any) => diagnostics.push(makeDiagnostic(usageInfo))
 			};

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,6 +126,7 @@ function browsersListParser(data: string): string[] {
 		}
 	});
 
+	connection.console.info(`The following browser scope has been detected: ${browsers.join(', ')}`);
 	return browsers;
 }
 
@@ -176,19 +177,20 @@ function doValidate(document: TextDocument): any {
 		}
 	}
 
-	getConfig(fsPath).then(() => {
-		const linterOptions = {
-			browsers: browserConfig,
-			ignore: editorSettings.ignore,
-			onFeatureUsage: (usageInfo: any) => diagnostics.push(makeDiagnostic(usageInfo))
-		};
+	getConfig(fsPath)
+		.then(() => {
+			const linterOptions = {
+				browsers: browserConfig,
+				ignore: editorSettings.ignore,
+				onFeatureUsage: (usageInfo: any) => diagnostics.push(makeDiagnostic(usageInfo))
+			};
 
-		postcss(linter(linterOptions))
-			.process(content, syntax && { syntax })
-			.then(() => {
-				connection.sendDiagnostics({ diagnostics, uri });
-			});
-	});
+			postcss(linter(linterOptions))
+				.process(content, syntax && { syntax })
+				.then(() => {
+					connection.sendDiagnostics({ diagnostics, uri });
+				});
+		});
 }
 
 // The documents manager listen for text document create, change
@@ -250,7 +252,6 @@ connection.onDidChangeConfiguration((params) => {
 });
 
 connection.onDidChangeWatchedFiles(() => {
-	console.log('update');
 	needUpdateConfig = true;
 
 	validateMany(allDocuments.all());

--- a/src/server.ts
+++ b/src/server.ts
@@ -106,16 +106,11 @@ function getSyntax(language: string): any {
 }
 
 function browsersListParser(data: string): string[] {
-	const lines = data.replace(/#.*(?:\n|\r\n)/g, '').split(/\r?\n/);
-
-	const browsers: string[] = [];
-	lines.forEach((line) => {
-		if (line !== '') {
-			browsers.push(line.trim());
-		}
-	});
-
-	return browsers;
+	return data
+		.replace(/#.*(?:\n|\r\n)/g, '')
+		.split(/\r?\n/)
+		.filter((line: string) => line !== '')
+		.map((line: string) => line.trim());
 }
 
 function getBrowsersList(documentFsPath: string): Promise<string[]> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ let editorSettings: any;
 // "config"
 let configResolver: ConfigResolver;
 let needUpdateConfig = true;
-let browserScope: string[] = [];
+let browserScopeCache: string[] = [];
 
 const doiuseNotFound: string = [
 	'Failed to load doiuse library.',
@@ -156,16 +156,16 @@ function getConfig(documentFsPath: string): Promise<string[]> {
 	};
 
 	if (!needUpdateConfig) {
-		return Promise.resolve(browserScope);
+		return Promise.resolve(browserScopeCache);
 	}
 
 	return configResolver
 		.scan(documentFsPath, configResolverOptions)
 		.then((config: IConfig) => {
-			browserScope = <string[]>config.json;
+			browserScopeCache = <string[]>config.json;
 			needUpdateConfig = false;
 
-			return [];
+			return browserScopeCache;
 		});
 }
 
@@ -190,7 +190,7 @@ function doValidate(document: TextDocument): any {
 	}
 
 	return getConfig(fsPath)
-		.then(() => {
+		.then((browserScope) => {
 			const linterOptions = {
 				browsers: browserScope,
 				ignore: editorSettings.ignore,

--- a/src/server.ts
+++ b/src/server.ts
@@ -162,10 +162,6 @@ function getConfig(documentFsPath: string): Promise<string[]> {
 	return configResolver
 		.scan(documentFsPath, configResolverOptions)
 		.then((config: IConfig) => {
-			if (config && config.from === 'settings') {
-				browserScope = (<any>config.json).browsers || [];
-			}
-
 			browserScope = <string[]>config.json;
 			needUpdateConfig = false;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -139,7 +139,6 @@ function browsersListParser(data: string): string[] {
 		}
 	});
 
-	connection.console.info(`The following browser scope has been detected: ${browsers.join(', ')}`);
 	return browsers;
 }
 
@@ -165,6 +164,7 @@ function getBrowsersList(documentFsPath: string): Promise<string[]> {
 			browsersListCache = <string[]>config.json;
 			needUpdateConfig = false;
 
+			connection.console.info(`The following browser scope has been detected: ${browsersListCache.join(', ')}`);
 			return browsersListCache;
 		});
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ let editorSettings: any;
 // "config"
 let configResolver: ConfigResolver;
 let needUpdateConfig = true;
-let browserConfig: any = [];
+let browserScope: string[] = [];
 
 const doiuseNotFound: string = [
 	'Failed to load doiuse library.',
@@ -156,17 +156,17 @@ function getConfig(documentFsPath: string): Promise<string[]> {
 	};
 
 	if (!needUpdateConfig) {
-		return Promise.resolve(browserConfig);
+		return Promise.resolve(browserScope);
 	}
 
 	return configResolver
 		.scan(documentFsPath, configResolverOptions)
 		.then((config: IConfig) => {
 			if (config && config.from === 'settings') {
-				browserConfig = (<any>config.json).browsers || [];
+				browserScope = (<any>config.json).browsers || [];
 			}
 
-			browserConfig = config.json;
+			browserScope = <string[]>config.json;
 			needUpdateConfig = false;
 
 			return [];
@@ -196,7 +196,7 @@ function doValidate(document: TextDocument): any {
 	return getConfig(fsPath)
 		.then(() => {
 			const linterOptions = {
-				browsers: browserConfig,
+				browsers: browserScope,
 				ignore: editorSettings.ignore,
 				onFeatureUsage: (usageInfo: any) => diagnostics.push(makeDiagnostic(usageInfo))
 			};

--- a/src/server.ts
+++ b/src/server.ts
@@ -183,14 +183,12 @@ function validate(documents: TextDocument[]): void {
 	const tracker = new ErrorMessageTracker();
 
 	Promise
-		.all(
-			documents.map((document) =>
-				validateDocument(document)
-					.catch((err: Error) => {
-						tracker.add(getErrorMessage(err, document));
-					})
-			)
-		)
+		.all(documents.map((document) =>
+			validateDocument(document)
+				.catch((err: Error) => {
+					tracker.add(getErrorMessage(err, document));
+				})
+		))
 		.then(() => {
 			tracker.sendErrors(connection);
 		});

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,8 +36,8 @@ const allDocuments: TextDocuments = new TextDocuments();
 
 // "global" settings
 let workspaceFolder: string;
+let workspaceSettings: any;
 let linter: any;
-let editorSettings: any;
 
 // "config"
 let configResolver: ConfigResolver;
@@ -53,7 +53,7 @@ const doiuseNotFound: string = [
 function makeDiagnostic(problem: any): Diagnostic {
 	const source = problem.usage.source;
 	const message: string = problem.message.replace(/<input css \d+>:\d*:\d*:\s/, '');
-	const level: string = editorSettings.messageLevel;
+	const level: string = workspaceSettings.messageLevel;
 
 	const severityLevel = <any>{
 		Error: DiagnosticSeverity.Error,
@@ -119,7 +119,7 @@ function getBrowsersList(documentFsPath: string): Promise<string[]> {
 		configFiles: [
 			'browserslist'
 		],
-		editorSettings: editorSettings.browsers || null,
+		editorSettings: workspaceSettings.browsers || null,
 		parsers: [
 			{ pattern: /.*list$/, parser: browsersListParser }
 		]
@@ -149,13 +149,13 @@ function validateDocument(document: TextDocument): any {
 	const syntax = getSyntax(lang);
 
 	let fsPath: string = Files.uriToFilePath(uri);
-	if (editorSettings.ignoreFiles.length) {
+	if (workspaceSettings.ignoreFiles.length) {
 		if (workspaceFolder) {
 			fsPath = path.relative(workspaceFolder, fsPath);
 		}
 
-		const match = micromatch([fsPath], editorSettings.ignoreFiles);
-		if (editorSettings.ignoreFiles && match.length !== 0) {
+		const match = micromatch([fsPath], workspaceSettings.ignoreFiles);
+		if (workspaceSettings.ignoreFiles && match.length !== 0) {
 			return diagnostics;
 		}
 	}
@@ -164,7 +164,7 @@ function validateDocument(document: TextDocument): any {
 		.then((browsersList) => {
 			const linterOptions = {
 				browsers: browsersList,
-				ignore: editorSettings.ignore,
+				ignore: workspaceSettings.ignore,
 				onFeatureUsage: (usageInfo: any) => diagnostics.push(makeDiagnostic(usageInfo))
 			};
 
@@ -233,7 +233,7 @@ connection.onInitialize((params) => {
 });
 
 connection.onDidChangeConfiguration((params) => {
-	editorSettings = params.settings.doiuse;
+	workspaceSettings = params.settings.doiuse;
 
 	validate(allDocuments.all());
 });
@@ -247,13 +247,13 @@ connection.onDidChangeWatchedFiles(() => {
 allDocuments.listen(connection);
 
 allDocuments.onDidChangeContent((event) => {
-	if (editorSettings.run === 'onType') {
+	if (workspaceSettings.run === 'onType') {
 		validate([event.document]);
 	}
 });
 
 allDocuments.onDidSave((event) => {
-	if (editorSettings.run === 'onSave') {
+	if (workspaceSettings.run === 'onSave') {
 		validate([event.document]);
 	}
 });


### PR DESCRIPTION
You're trying to handle asynchronous Promise rejections with synchronous `try { .. } catch (err) { .. }` blocks, which results in unhandled Promise rejections.

The following warning is thrown on the console:
`DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`

The issues is the following
```
arr = [];
try {
    Promise.reject('');
} catch (err) {
    arr.push(err);
}
// code that should run after the Promises
console.log(arr.length); // 0
// Uncaught (in promise)
```

Instead, the following code is the solution
```
arr = [];
Promise
    .all([
        Promise.reject('err1').catch((err) => arr.push(err)),
        Promise.reject('err2').catch((err) => arr.push(err))
    ])
    .then(() => {
        // code that should run after the Promises
        console.log(arr.length); // 2
    });
```

Also, after a little investigation I've found that in some cases the extension exits silently.